### PR TITLE
[Minor] Fix Image bugs causing images to be lower fidelity.

### DIFF
--- a/.changeset/spotty-lemons-impress.md
+++ b/.changeset/spotty-lemons-impress.md
@@ -1,0 +1,6 @@
+---
+'graph-image': minor
+---
+
+- Fixed bug where images were being stretched to fit their container. This could cause some incompatibilities if your layout depended on this bug hence why this is a minor
+- Fixed bug where images were pinned to 800px regardless of actual size.

--- a/demo/src/lib/Banner/Banner.svelte
+++ b/demo/src/lib/Banner/Banner.svelte
@@ -5,11 +5,5 @@
 </script>
 
 <div class="banner">
-	<GraphImage image={logo} fit="clip" load="eager" />
+	<GraphImage image={{ ...logo, width: 1200, height: 400 }} fit="clip" load="eager" />
 </div>
-
-<style>
-	.banner {
-		max-height: 360px;
-	}
-</style>

--- a/demo/src/routes/+layout.svelte
+++ b/demo/src/routes/+layout.svelte
@@ -1,9 +1,10 @@
 <script>
 	import { dev } from '$app/environment';
-	import { inject } from '@vercel/analytics'
+	import { inject } from '@vercel/analytics';
 
-	inject({ mode: dev ? 'development' : 'production' })
+	inject({ mode: dev ? 'development' : 'production' });
 </script>
+
 <main>
 	<div>
 		<slot />

--- a/demo/src/routes/+page.server.ts
+++ b/demo/src/routes/+page.server.ts
@@ -50,8 +50,8 @@ export const load: PageServerLoad = async () => {
 	];
 	let logo: GraphImageTypes.GraphAsset = {
 		handle: 'fONBVATVKYm2eBRtzA76',
-		height: 510,
-		width: 1603
+		height: 400,
+		width: 1200
 	};
 
 	try {

--- a/demo/src/routes/+page.svelte
+++ b/demo/src/routes/+page.svelte
@@ -57,7 +57,7 @@
 			<GraphImage
 				title="Sample"
 				alt="Sample"
-				image={{ ...image, width: 3840, height: 2160 }}
+				image={{ ...image, width: 590, height: 331 }}
 				fit="clip"
 				withWebp
 				maxWidth={1200}
@@ -154,10 +154,6 @@
 		border-top: 1px solid #333;
 		padding-top: 1rem;
 		color: #a9a9a9;
-	}
-
-	.banner {
-		max-height: 360px;
 	}
 
 	.gallery {

--- a/graph-image/src/lib/GraphImage/GraphImage.svelte
+++ b/graph-image/src/lib/GraphImage/GraphImage.svelte
@@ -4,7 +4,7 @@
 	import type { Fit, GraphAsset, Load, Watermark } from './types.ts';
 
 	export let image: GraphAsset;
-	export let maxWidth: number = 800;
+	export let maxWidth: number | undefined = undefined;
 	export let fadeIn: boolean = true;
 	export let fit: Fit = 'crop';
 	export let withWebp: boolean = true;
@@ -41,7 +41,7 @@
 		image,
 		withWebp,
 		baseURI,
-		maxWidth,
+		maxWidth ?? image.width,
 		fit,
 		quality,
 		sharpen,
@@ -75,7 +75,14 @@
 		<div class="full" style="padding-bottom: {100 / (image.width / image.height)}%" />
 
 		{#if blurryPlaceholder && load == 'lazy'}
-			<Image {alt} {title} src={imageData.thumbSrc} {load} />
+			<Image
+				{alt}
+				{title}
+				src={imageData.thumbSrc}
+				{load}
+				width={image.width}
+				height={image.height}
+			/>
 		{/if}
 
 		{#if backgroundColor}
@@ -95,6 +102,8 @@
 				opacity={fadeIn ? 0 : 1}
 				sizes={imageData.sizes}
 				{load}
+				width={image.width}
+				height={image.height}
 				on:imageLoad={onImageLoaded}
 			/>
 		{/if}

--- a/graph-image/src/lib/GraphImage/GraphImage.svelte
+++ b/graph-image/src/lib/GraphImage/GraphImage.svelte
@@ -7,7 +7,7 @@
 	export let alt: string = '';
 	export let baseURI: string = 'https://media.graphassets.com';
 	export let title: string = '';
-	
+
 	// --- Styling and Presentation ---
 	export let fit: Fit = 'crop';
 	export let maxWidth: number | undefined = undefined;

--- a/graph-image/src/lib/GraphImage/Image.svelte
+++ b/graph-image/src/lib/GraphImage/Image.svelte
@@ -5,6 +5,11 @@
 	const dispatch = createEventDispatcher();
 	export let src: string;
 	export let alt: string;
+	export let height: number;
+	export let width: number;
+	export let srcset: string | undefined = undefined;
+	export let sizes: string | undefined = undefined;
+	export let title: string | undefined = undefined;
 	export let opacity: 0 | 1 = 0;
 	export let transitionDelay: string = '0.25s';
 	export let transition: string = 'opacity 0.5s';
@@ -19,30 +24,21 @@
 
 		dispatch('imageLoad');
 	}
+
+	$: style = `max-width: ${width}px; max-height: ${height}px; ${
+		load === 'eager'
+			? ''
+			: `transition: ${transition}; transition-delay: ${transitionDelay}; opacity: ${opacity};`
+	}`;
 </script>
 
 <svelte:head>
 	{#if load === 'eager'}
-		<link
-			rel="preload"
-			as="image"
-			href={src}
-			imagesrcset={$$props?.srcset}
-			imagesizes={$$props?.sizes}
-		/>
+		<link rel="preload" as="image" href={src} imagesrcset={srcset} imagesizes={sizes} />
 	{/if}
 </svelte:head>
 
-<img
-	{...$$props}
-	{id}
-	{src}
-	{alt}
-	style={load === 'eager'
-		? ''
-		: `transition: ${transition}; transition-delay: ${transitionDelay}; opacity: ${opacity};`}
-	on:load={handleLoading}
-/>
+<img {id} {src} {srcset} {sizes} {alt} {style} {title} on:load={handleLoading} />
 
 <style>
 	img {
@@ -50,7 +46,6 @@
 		top: 0;
 		left: 0;
 		width: 100%;
-		height: 100%;
 		object-fit: cover;
 		object-position: center;
 	}

--- a/graph-image/src/lib/GraphImage/_utils.test.ts
+++ b/graph-image/src/lib/GraphImage/_utils.test.ts
@@ -39,7 +39,7 @@ describe('_utils.ts // Utility Functions', () => {
 			expect(result.thumbSrc).toBe(
 				'http://example.com/resize=w:20,h:20,fit:crop/blur=amount:2/compress/sampleHandle'
 			);
-			expect(result.sizes).toBe('(max-width: 500px) 100vw, 500px');
+			expect(result.sizes).toBe('(min-width: 500px) 500px, 100vw');
 
 			const expectedSrcSet =
 				'http://example.com/resize=w:125,h:1080,fit:crop/auto_image/compress/sampleHandle 125w,\n' +

--- a/graph-image/src/lib/GraphImage/_utils.ts
+++ b/graph-image/src/lib/GraphImage/_utils.ts
@@ -112,7 +112,7 @@ export function srcSet(
 }
 
 export function imgSizes(maxWidth: number): string {
-	return `(max-width: ${maxWidth}px) 100vw, ${maxWidth}px`;
+	return `(min-width: ${maxWidth}px) ${maxWidth}px, 100vw`;
 }
 
 export function createWatermarkTransformation(watermark: Watermark): string {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "turbo run format",
+    "test": "turbo run test",
     "publish-packages": "turbo run build && turbo run test && changeset version && changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
- Fixed bug where images were being stretched to fit their container. This could cause some incompatibilities if your layout depended on this bug hence why this is a minor. 
- Fixed bug where images were pinned to 800px regardless of actual size.