### PR TITLE
[Minor] Add Source and Image Component + other small performance improvements. 

### DIFF
--- a/.changeset/red-mugs-protect.md
+++ b/.changeset/red-mugs-protect.md
@@ -1,0 +1,6 @@
+---
+'graph-image': minor
+---
+
+- Default blurryPlaceholder prop to false
+- Added `Source` and `Image` components for [art-direction use case](https://web.dev/articles/codelab-art-direction)

--- a/demo/src/routes/+page.server.ts
+++ b/demo/src/routes/+page.server.ts
@@ -5,15 +5,14 @@ import { GraphQLClient, gql } from 'graphql-request';
 import { parse } from 'graphql';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
-
-export const load: PageServerLoad = async ({fetch}) => {
+export const load: PageServerLoad = async ({ fetch }) => {
 	const client = new GraphQLClient(HYGRAPH_URL, {
 		headers: {
 			Authorization: `Bearer ${HYGRAPH_TOKEN}`
 		},
 		fetch
 	});
-	
+
 	const query: TypedDocumentNode<
 		{
 			pageTextContent: { features: Array<string>; headline: string };

--- a/demo/src/routes/+page.server.ts
+++ b/demo/src/routes/+page.server.ts
@@ -5,13 +5,15 @@ import { GraphQLClient, gql } from 'graphql-request';
 import { parse } from 'graphql';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
-const client = new GraphQLClient(HYGRAPH_URL, {
-	headers: {
-		Authorization: `Bearer ${HYGRAPH_TOKEN}`
-	}
-});
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({fetch}) => {
+	const client = new GraphQLClient(HYGRAPH_URL, {
+		headers: {
+			Authorization: `Bearer ${HYGRAPH_TOKEN}`
+		},
+		fetch
+	});
+	
 	const query: TypedDocumentNode<
 		{
 			pageTextContent: { features: Array<string>; headline: string };

--- a/graph-image/README.md
+++ b/graph-image/README.md
@@ -54,22 +54,80 @@ Here's an example using a static asset object.
 
 ## Props
 
-| Name                | Type                             | Description                                                                                                                                                                                                                                                                            |
-| ------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `image`             | `object`                         | An object of shape `{ handle, width, height }`. Handle is an identifier required to display the image and both `width` and `height` are required to display a correct placeholder and aspect ratio for the image. You can get all 3 by just putting all 3 in your image-getting query. |
-| `maxWidth`          | `number`                         | Maximum width you'd like your image to take up. (ex. If your image container is resizing dynamically up to a width of 1200, put it as a `maxWidth`) |
-| `fadeIn`            | `bool`                           | Do you want your image to fade in on load? Defaults to `true` |
-| `fit`               | `"clip"\|"crop"\|"scale"\|"max"\|"center-contain" (Experimental)` | When resizing the image, how would you like it to fit the new dimensions? Defaults to `crop`. You can read more about resizing [here](https://www.filestack.com/docs/api/processing/#resize). "center-contain" is experimental and will use 'clip' for the purposes for resizing. |
-| `withWebp`          | `bool`                           | If webp is supported by the browser, the images will be served with `.webp` extension. (Recommended) |
-| `title`             | `string`                         | Passed to the `img` element |
-| `alt`               | `string`                         | Passed to the `img` element |
-| `style`             | `object`                         | Spread into the default styles in the wrapper div |
-| `position`          | `string`                         | Defaults to `relative`. Pass in `absolute` to make the component `absolute` positioned |
-| `blurryPlaceholder` | `bool`                           | Would you like to display a blurry placeholder for your loading image? Defaults to `true`. |
-| `backgroundColor`   | `string\|bool`                   | Set a colored background placeholder. If true, uses "lightgray" for the color. You can also pass in any valid color string. |
-| `baseURI`           | `string`                         | Set the base src from where the images are requested. Base URI Defaults to `https://media.graphassets.com` |
-| `quality`           | `number`			             | Set the image quality value between 1 & 100 |
-| `sharpen`           | `number`			             | Set the image sharpen value between 0 and 20 |
-| `rotate`            | `number`                         | Set the image rotation between 0 & 360 degrees |
-| `watermark`         | `object`                         | An object of shape `{ handle, size, position }`. Handle is an identifier required to display the image. `size` is an optional `number`. `position` is required and can either be a `string` `HorizontalPosition` or a `tuple` of shape `[VerticalPosition, HorizontalPosition]` where `VerticalPosition` can be `'top' \| 'middle' \| 'bottom'` and `HorizontalPosition` can be `'left' \| 'center' \| 'right` |
-| `load` 			  | `"lazy"\|"eager"` 			             | To prioritize loading speed, set `load` to `eager`. This will place preload tags in the `<head>` and will remove transition effects. Defaults to `lazy`. |
+| Name                | Type                                                              | Description                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `image`             | `object`                                                          | An object of shape `{ handle, width, height }`. Handle is an identifier required to display the image and both `width` and `height` are required to display a correct placeholder and aspect ratio for the image. You can get all 3 by just putting all 3 in your image-getting query.                                                                                                                         |
+| `maxWidth`          | `number`                                                          | Maximum width you'd like your image to take up. (ex. If your image container is resizing dynamically up to a width of 1200, put it as a `maxWidth`)                                                                                                                                                                                                                                                            |
+| `fadeIn`            | `bool`                                                            | Do you want your image to fade in on load? Defaults to `true`                                                                                                                                                                                                                                                                                                                                                  |
+| `fit`               | `"clip"\|"crop"\|"scale"\|"max"\|"center-contain" (Experimental)` | When resizing the image, how would you like it to fit the new dimensions? Defaults to `crop`. You can read more about resizing [here](https://www.filestack.com/docs/api/processing/#resize). "center-contain" is experimental and will use 'clip' for the purposes for resizing.                                                                                                                              |
+| `withWebp`          | `bool`                                                            | If webp is supported by the browser, the images will be served with `.webp` extension. (Recommended)                                                                                                                                                                                                                                                                                                           |
+| `title`             | `string`                                                          | Passed to the `img` element                                                                                                                                                                                                                                                                                                                                                                                    |
+| `alt`               | `string`                                                          | Passed to the `img` element                                                                                                                                                                                                                                                                                                                                                                                    |
+| `style`             | `object`                                                          | Spread into the default styles in the wrapper div                                                                                                                                                                                                                                                                                                                                                              |
+| `position`          | `string`                                                          | Defaults to `relative`. Pass in `absolute` to make the component `absolute` positioned                                                                                                                                                                                                                                                                                                                         |
+| `blurryPlaceholder` | `bool`                                                            | Would you like to display a blurry placeholder for your loading image? Defaults to `true`.                                                                                                                                                                                                                                                                                                                     |
+| `backgroundColor`   | `string\|bool`                                                    | Set a colored background placeholder. If true, uses "lightgray" for the color. You can also pass in any valid color string.                                                                                                                                                                                                                                                                                    |
+| `baseURI`           | `string`                                                          | Set the base src from where the images are requested. Base URI Defaults to `https://media.graphassets.com`                                                                                                                                                                                                                                                                                                     |
+| `quality`           | `number`                                                          | Set the image quality value between 1 & 100                                                                                                                                                                                                                                                                                                                                                                    |
+| `sharpen`           | `number`                                                          | Set the image sharpen value between 0 and 20                                                                                                                                                                                                                                                                                                                                                                   |
+| `rotate`            | `number`                                                          | Set the image rotation between 0 & 360 degrees                                                                                                                                                                                                                                                                                                                                                                 |
+| `watermark`         | `object`                                                          | An object of shape `{ handle, size, position }`. Handle is an identifier required to display the image. `size` is an optional `number`. `position` is required and can either be a `string` `HorizontalPosition` or a `tuple` of shape `[VerticalPosition, HorizontalPosition]` where `VerticalPosition` can be `'top' \| 'middle' \| 'bottom'` and `HorizontalPosition` can be `'left' \| 'center' \| 'right` |
+| `load`              | `"lazy"\|"eager"`                                                 | To prioritize loading speed, set `load` to `eager`. This will place preload tags in the `<head>` and will remove transition effects. Defaults to `lazy`.                                                                                                                                                                                                                                                       |
+
+## Source and Image
+
+You can also show the `Source` and `Image` components to show different images at different breakpoints.
+
+```html
+<script>
+	import { Image, Source } from 'graph-image';
+</script>
+
+<picture>
+	<source
+		handle="uQrLj1QRWKJnlQv1sEmC"
+		alt="Mobile Image"
+		width="{768}"
+		height="{800}"
+		media="(max-width: 600px)"
+	/>
+	<image handle="uQrLj1QRWKJnlQv1sEmC" alt="Desktop Image" width="{1920}" height="{1800}" />
+</picture>
+```
+
+### Preloading Source and Image
+
+You can also Preload `Source` and `Image` components please note that because responsive preload has no notion of "order" or "first match", the media queries [will need to be translated](https://web.dev/articles/preload-responsive-images#preload_and_picture)
+
+```html
+<script>
+	import { Image, Source } from 'graph-image';
+</script>
+
+<picture>
+	<source
+		handle="sdgegrrnlQvsd23vcl"
+		alt="Mobile Image"
+		width="{400}"
+		height="{400}"
+		media="(max-width: 400px)"
+		preloadMedia="(max-width: 400px)"
+	/>
+	<source
+		handle="adWEFKJnlQvsda1s12e"
+		alt="MD Image"
+		width="{768}"
+		height="{800}"
+		media="(max-width: 800px)"
+		preloadMedia="(min-width: 400.1px and (max-width: 800px)"
+	/>
+	<image
+		handle="uQrLj1QRWKJnlQv1sEmC"
+		alt="Desktop Image"
+		width="{1920}"
+		height="{1800}"
+		loading="eager"
+		media="(min-width: 800.1px)"
+	/>
+</picture>
+```

--- a/graph-image/src/lib/GraphImage/GraphImage.svelte
+++ b/graph-image/src/lib/GraphImage/GraphImage.svelte
@@ -80,6 +80,7 @@
 				width={20}
 				height={20}
 				opacity={1}
+				blur={2}
 				absolute
 			/>
 		{/if}

--- a/graph-image/src/lib/GraphImage/GraphImage.svelte
+++ b/graph-image/src/lib/GraphImage/GraphImage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Image from './Image.svelte';
-	import { bgColor, createFinalURL, inImageCache, listenToIntersections } from './_utils.js';
+	import { bgColor, inImageCache, listenToIntersections } from './_utils.js';
 	import type { Fit, GraphAsset, Load, Watermark } from './types.ts';
 
 	export let image: GraphAsset;
@@ -16,7 +16,7 @@
 
 	// --- Image Enhancements and Effects ---
 	export let backgroundColor: string | boolean = '';
-	export let blurryPlaceholder: boolean = true;
+	export let blurryPlaceholder: boolean = false;
 	export let fadeIn: boolean = true;
 	export let quality: number | undefined = undefined;
 	export let rotate: number | undefined = undefined;
@@ -43,17 +43,6 @@
 	$: styleString = Object.entries(style)
 		.map(([key, value]) => `${key}: ${value};`)
 		.join('');
-	$: imageData = createFinalURL(
-		image,
-		withWebp,
-		baseURI,
-		maxWidth ?? image.width,
-		fit,
-		quality,
-		sharpen,
-		rotate,
-		watermark
-	);
 
 	$: if (imageInnerWrapper && IOSupported) {
 		listenToIntersections(imageInnerWrapper, () => {
@@ -84,13 +73,14 @@
 			<Image
 				{alt}
 				{title}
-				src={imageData.thumbSrc}
-				{load}
-				width={image.width}
-				height={image.height}
-				transition="none"
-				transitionDelay="0ms"
-				thumb
+				{baseURI}
+				handle={image.handle}
+				load="eager"
+				fit="crop"
+				width={20}
+				height={20}
+				opacity={1}
+				absolute
 			/>
 		{/if}
 
@@ -106,15 +96,22 @@
 			<Image
 				{alt}
 				{title}
-				srcset={imageData.srcSetImgs}
-				src={imageData.finalSrc}
-				opacity={fadeIn ? 0 : 1}
-				sizes={imageData.sizes}
+				handle={image.handle}
 				{load}
+				{baseURI}
+				{maxWidth}
+				{fit}
+				{quality}
+				{rotate}
+				{sharpen}
+				{withWebp}
+				{watermark}
+				opacity={fadeIn ? 0 : 1}
 				width={image.width}
 				height={image.height}
 				center={fit === 'center-contain'}
-				on:imageLoad={onImageLoaded}
+				absolute
+				on:load={onImageLoaded}
 			/>
 		{/if}
 	</div>

--- a/graph-image/src/lib/GraphImage/Image.svelte
+++ b/graph-image/src/lib/GraphImage/Image.svelte
@@ -1,54 +1,89 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
-	import type { Load } from './types.js';
+	import type { Fit, Load, Watermark } from './types.js';
+	import { createFinalURL } from './_utils.js';
 
-	const dispatch = createEventDispatcher();
-	export let src: string;
+	export let handle: string;
 	export let alt: string;
 	export let height: number;
 	export let width: number;
-	export let srcset: string | undefined = undefined;
-	export let sizes: string | undefined = undefined;
 	export let title: string | undefined = undefined;
 	export let opacity: 0 | 1 = 0;
 	export let transitionDelay: string = '0.25s';
 	export let transition: string = 'opacity 0.5s';
-	export let load: Load = 'lazy';
-	export let thumb: boolean = false;
 	export let center: boolean = false;
+	export let baseURI: string = 'https://media.graphassets.com';
+	export let media: string | undefined = undefined;
+	export let id: string | undefined = undefined;
 
-	let id = crypto.randomUUID().slice(0, 8);
+	// --- Styling and Presentation ---
+	export let fit: Fit = 'crop';
+	export let maxWidth: number | undefined = undefined;
+	export let load: Load = 'lazy';
+	export let absolute = false;
 
-	function handleLoading(e: Event) {
-		if (!(e.target instanceof HTMLImageElement)) return;
+	// --- Image Enhancements and Effects ---
+	export let quality: number | undefined = undefined;
+	export let rotate: number | undefined = undefined;
+	export let sharpen: number | undefined = undefined;
+	export let withWebp: boolean = true;
+	// --- Miscellaneous Features ---
+	export let watermark: Watermark | undefined = undefined;
 
+	function handleLoading(e: { target: HTMLImageElement } & Event) {
 		if (e.target.complete) opacity = 1;
-
-		dispatch('imageLoad');
 	}
 
 	$: style = `max-width: ${width}px; max-height: ${height}px; ${
 		load === 'eager'
 			? ''
-			: `transition: ${transition}; transition-delay: ${transitionDelay}; opacity: ${thumb ? 1 : opacity};`
+			: `transition: ${transition}; transition-delay: ${transitionDelay}; opacity:
+					 1 
+			  ;`
 	} ${center ? `aspect-ratio: ${width} / ${height}; object-fit: contain !important;` : ``}`;
+
+	$: ({ sizes, srcset, src } = createFinalURL(
+		{ width, height, handle },
+		withWebp,
+		baseURI,
+		maxWidth ?? width,
+		fit,
+		quality,
+		sharpen,
+		rotate,
+		watermark
+	));
 </script>
 
 <svelte:head>
 	{#if load === 'eager'}
-		<link rel="preload" as="image" href={src} imagesrcset={srcset} imagesizes={sizes} />
+		<link rel="preload" as="image" href={src} imagesrcset={srcset} imagesizes={sizes} {media} />
 	{/if}
 </svelte:head>
 
-<img {id} {src} {srcset} {sizes} {alt} {style} {title} on:load={handleLoading} />
+<img
+	{id}
+	{src}
+	{srcset}
+	{sizes}
+	{alt}
+	{style}
+	{title}
+	class:absolute
+	on:load={handleLoading}
+	on:load
+	on:error
+/>
 
 <style>
 	img {
-		position: absolute;
-		top: 0;
-		left: 0;
 		width: 100%;
 		object-fit: cover;
 		object-position: center;
+	}
+
+	.absolute {
+		position: absolute;
+		top: 0;
+		left: 0;
 	}
 </style>

--- a/graph-image/src/lib/GraphImage/Image.svelte
+++ b/graph-image/src/lib/GraphImage/Image.svelte
@@ -25,6 +25,8 @@
 	export let quality: number | undefined = undefined;
 	export let rotate: number | undefined = undefined;
 	export let sharpen: number | undefined = undefined;
+	export let blur: number | undefined = undefined;
+
 	export let withWebp: boolean = true;
 	// --- Miscellaneous Features ---
 	export let watermark: Watermark | undefined = undefined;
@@ -50,6 +52,7 @@
 		quality,
 		sharpen,
 		rotate,
+		blur,
 		watermark
 	));
 </script>

--- a/graph-image/src/lib/GraphImage/Source.svelte
+++ b/graph-image/src/lib/GraphImage/Source.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Fit } from './types.js';
+	import type { Fit, Watermark } from './types.js';
 	import { createFinalURL } from './_utils.js';
 
 	export let handle: string;
@@ -16,7 +16,10 @@
 	export let quality: number | undefined = undefined;
 	export let rotate: number | undefined = undefined;
 	export let sharpen: number | undefined = undefined;
+	export let blur: number | undefined = undefined;
 	export let withWebp: boolean = true;
+	// --- Miscellaneous Features ---
+	export let watermark: Watermark | undefined = undefined;
 
 	$: ({ sizes, srcset, src } = createFinalURL(
 		{ width, height, handle },
@@ -26,7 +29,9 @@
 		fit,
 		quality,
 		sharpen,
-		rotate
+		rotate,
+		blur,
+		watermark
 	));
 </script>
 

--- a/graph-image/src/lib/GraphImage/Source.svelte
+++ b/graph-image/src/lib/GraphImage/Source.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import type { Fit } from './types.js';
+	import { createFinalURL } from './_utils.js';
+
+	export let handle: string;
+	export let height: number;
+	export let width: number;
+	export let media: string;
+	export let preloadMedia: string | undefined = undefined;
+	export let maxWidth: number | undefined = undefined;
+	export let baseURI: string = 'https://media.graphassets.com';
+
+	// --- Styling and Presentation ---
+	export let fit: Fit = 'crop';
+
+	export let quality: number | undefined = undefined;
+	export let rotate: number | undefined = undefined;
+	export let sharpen: number | undefined = undefined;
+	export let withWebp: boolean = true;
+
+	$: ({ sizes, srcset, src } = createFinalURL(
+		{ width, height, handle },
+		withWebp,
+		baseURI,
+		maxWidth ?? width,
+		fit,
+		quality,
+		sharpen,
+		rotate
+	));
+</script>
+
+<svelte:head>
+	{#if preloadMedia}
+		<link
+			rel="preload"
+			as="image"
+			href={src}
+			imagesrcset={srcset}
+			imagesizes={sizes}
+			media={preloadMedia}
+		/>
+	{/if}
+</svelte:head>
+
+<source {src} {srcset} {sizes} {media} />

--- a/graph-image/src/lib/GraphImage/_utils.test.ts
+++ b/graph-image/src/lib/GraphImage/_utils.test.ts
@@ -33,12 +33,7 @@ describe('_utils.ts // Utility Functions', () => {
 				undefined,
 				undefined
 			);
-			expect(result.finalSrc).toBe(
-				'http://example.com/resize=w:1920,h:1080,fit:crop/auto_image/compress/sampleHandle'
-			);
-			expect(result.thumbSrc).toBe(
-				'http://example.com/resize=w:20,h:20,fit:crop/blur=amount:2/compress/sampleHandle'
-			);
+
 			expect(result.sizes).toBe('(min-width: 500px) 500px, 100vw');
 
 			const expectedSrcSet =
@@ -49,7 +44,7 @@ describe('_utils.ts // Utility Functions', () => {
 				'http://example.com/resize=w:1000,h:1080,fit:crop/auto_image/compress/sampleHandle 1000w,\n' +
 				'http://example.com/resize=w:1500,h:1080,fit:crop/auto_image/compress/sampleHandle 1500w,\n' +
 				'http://example.com/resize=w:1920,h:1080,fit:crop/auto_image/compress/sampleHandle 1920w';
-			expect(result.srcSetImgs).toBe(expectedSrcSet);
+			expect(result.srcset).toBe(expectedSrcSet);
 		});
 
 		it('should apply quality transformation', () => {
@@ -69,7 +64,7 @@ describe('_utils.ts // Utility Functions', () => {
 				undefined,
 				undefined
 			);
-			expect(result.finalSrc).toContain('quality=value:90');
+			expect(result.src).toContain('quality=value:90');
 		});
 
 		it('should apply sharpen transformation', () => {
@@ -89,7 +84,7 @@ describe('_utils.ts // Utility Functions', () => {
 				undefined,
 				undefined
 			);
-			expect(result.finalSrc).toContain('sharpen=amount:10');
+			expect(result.src).toContain('sharpen=amount:10');
 		});
 
 		it('should apply rotate transformation', () => {
@@ -109,7 +104,7 @@ describe('_utils.ts // Utility Functions', () => {
 				90,
 				undefined
 			);
-			expect(result.finalSrc).toContain('rotate=deg:90');
+			expect(result.src).toContain('rotate=deg:90');
 		});
 
 		it('should apply watermark transformation', () => {
@@ -134,9 +129,7 @@ describe('_utils.ts // Utility Functions', () => {
 				undefined,
 				watermark
 			);
-			expect(result.finalSrc).toContain(
-				'watermark=position:[top,right],file:watermarkHandle,size:30'
-			);
+			expect(result.src).toContain('watermark=position:[top,right],file:watermarkHandle,size:30');
 		});
 	});
 

--- a/graph-image/src/lib/GraphImage/_utils.test.ts
+++ b/graph-image/src/lib/GraphImage/_utils.test.ts
@@ -127,6 +127,7 @@ describe('_utils.ts // Utility Functions', () => {
 				undefined,
 				undefined,
 				undefined,
+				undefined,
 				watermark
 			);
 			expect(result.src).toContain('watermark=position:[top,right],file:watermarkHandle,size:30');

--- a/graph-image/src/lib/GraphImage/_utils.ts
+++ b/graph-image/src/lib/GraphImage/_utils.ts
@@ -117,12 +117,6 @@ export function imgSizes(maxWidth: number): string {
 	return `(min-width: ${maxWidth}px) ${maxWidth}px, 100vw`;
 }
 
-export function calculateThumbSize(handle: string, baseURI: string) {
-	const thumbBase = constructURL(handle, false, baseURI);
-	const thumbSize = { width: 20, height: 20, fit: 'crop' };
-	return thumbBase(resizeImage(thumbSize))(['blur=amount:2']);
-}
-
 function createWatermarkTransformation(watermark: Watermark): string {
 	const { handle, size, position } = watermark;
 
@@ -155,9 +149,10 @@ function createFinalURL(
 	quality: number | undefined = undefined,
 	sharpen: number | undefined = undefined,
 	rotate: number | undefined = undefined,
+	blur: number | undefined = undefined,
 	watermark: Watermark | undefined = undefined
 ) {
-	const transforms = createTransformations(quality, sharpen, rotate, watermark);
+	const transforms = createTransformations(quality, sharpen, rotate, blur, watermark);
 	const srcBase = constructURL(image.handle, withWebp, baseURI);
 
 	const sizedSrc = srcBase(resizeImage({ width: image.width, height: image.height, fit }));
@@ -176,6 +171,7 @@ function createTransformations(
 	quality: number | undefined,
 	sharpen: number | undefined,
 	rotate: number | undefined,
+	blur: number | undefined,
 	watermark: Watermark | undefined
 ) {
 	const transforms = [];
@@ -186,6 +182,10 @@ function createTransformations(
 
 	if (sharpen && sharpen <= 20) {
 		transforms.push(`sharpen=amount:${sharpen}`);
+	}
+
+	if (blur && blur > 0 && blur <= 100) {
+		transforms.push(`blur=amount:${blur}`);
 	}
 
 	if (rotate && rotate > 0 && rotate < 360) {

--- a/graph-image/src/lib/GraphImage/_utils.ts
+++ b/graph-image/src/lib/GraphImage/_utils.ts
@@ -104,7 +104,9 @@ function srcSet(
 ): string {
 	return srcWidths
 		.map((width) => {
-			const resizeOption = `resize=w:${Math.floor(width)},h:${Math.floor(height)},fit:${fit == 'center-contain' ? 'clip' : fit}`;
+			const resizeOption = `resize=w:${Math.floor(width)},h:${Math.floor(height)},fit:${
+				fit == 'center-contain' ? 'clip' : fit
+			}`;
 			const src = srcBase(resizeOption)(transforms);
 			return `${src} ${Math.floor(width)}w`;
 		})
@@ -113,6 +115,12 @@ function srcSet(
 
 export function imgSizes(maxWidth: number): string {
 	return `(min-width: ${maxWidth}px) ${maxWidth}px, 100vw`;
+}
+
+export function calculateThumbSize(handle: string, baseURI: string) {
+	const thumbBase = constructURL(handle, false, baseURI);
+	const thumbSize = { width: 20, height: 20, fit: 'crop' };
+	return thumbBase(resizeImage(thumbSize))(['blur=amount:2']);
 }
 
 function createWatermarkTransformation(watermark: Watermark): string {
@@ -144,30 +152,22 @@ function createFinalURL(
 	baseURI: string,
 	maxWidth: number,
 	fit: Fit,
-	quality: number | undefined,
-	sharpen: number | undefined,
-	rotate: number | undefined,
-	watermark: Watermark | undefined
+	quality: number | undefined = undefined,
+	sharpen: number | undefined = undefined,
+	rotate: number | undefined = undefined,
+	watermark: Watermark | undefined = undefined
 ) {
 	const transforms = createTransformations(quality, sharpen, rotate, watermark);
 	const srcBase = constructURL(image.handle, withWebp, baseURI);
-	const thumbBase = constructURL(image.handle, false, baseURI);
+
 	const sizedSrc = srcBase(resizeImage({ width: image.width, height: image.height, fit }));
-	const finalSrc = sizedSrc(transforms);
-	const thumbSize = { width: 20, height: 20, fit: 'crop' };
-	const thumbSrc = thumbBase(resizeImage(thumbSize))(['blur=amount:2']);
-	const srcSetImgs = srcSet(
-		srcBase,
-		getWidths(image.width, maxWidth),
-		image.height,
-		fit,
-		transforms
-	);
+	const src = sizedSrc(transforms);
+
+	const srcset = srcSet(srcBase, getWidths(image.width, maxWidth), image.height, fit, transforms);
 	const sizes = imgSizes(maxWidth);
 	return {
-		finalSrc,
-		thumbSrc,
-		srcSetImgs,
+		src,
+		srcset,
 		sizes
 	};
 }

--- a/graph-image/src/lib/index.js
+++ b/graph-image/src/lib/index.js
@@ -1,4 +1,6 @@
 import GraphImage from './GraphImage/GraphImage.svelte';
+import Image from './GraphImage/Image.svelte';
+import Source from './GraphImage/Source.svelte';
 import * as GraphImageTypes from './GraphImage/types';
 
-export { GraphImage, GraphImageTypes };
+export { GraphImage, Image, Source, GraphImageTypes };


### PR DESCRIPTION
# Overview
Added `Source` component and exposed `Image` component so different images can be displayed at different viewports.  Exposing the Image component also allows more fine-grained control. 

## Other changes
- Set `blurryPlaceholder` default to off. Since the `blurryPlaceholder` adds an extra network request, and therefore degrades performance. It should only be added when the use case demands it. I think in most cases people will not need the `blurryPlaceholder` since images load rather quickly when there is a small handful and therefore it should default to off.

- small code improvements


## Notes

Really couldn't test the demo because I do not have a Hygraph token  if I could get that Ill make sure it works. 